### PR TITLE
Fixed noReviews page and redirect when click on RatingSummary stars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- No reviews page
 
 ## [1.2.1] - 2019-09-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - No reviews page
 
+### Added
+- Clicking on RatingSummary stars now scrolls to reviews
+
 ## [1.2.1] - 2019-09-04
 ### Fixed
 - Stars weren't being filled correctly

--- a/messages/context.json
+++ b/messages/context.json
@@ -3,5 +3,5 @@
   "stars": "Stars",
   "rating-summary": "Rating summary",
   "review-form": "Review form",
-  "reviews": "Reviews"
+  "reviews": "({total, plural, one {# review} other {# reviews}})"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -3,5 +3,5 @@
   "stars": "Stars rating for {name}",
   "rating-summary": "Rating summary for {name}",
   "review-form": "Review form",
-  "reviews": "Show {name} reviews here"
+  "reviews": "({total, plural, one {# review} other {# reviews}})"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -3,5 +3,5 @@
   "stars": "Estrellas para {name}",
   "rating-summary": "Resumen de las valoraciones para {name}",
   "review-form": "Formulario de evaluación",
-  "reviews": "Mostrar las evaluaciones de {name} aquí"
+  "reviews": "({total, plural, one {# evaluación} other {# evaluaciones}})"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -3,5 +3,5 @@
   "stars": "Estrelas para {name}",
   "rating-summary": "Resumo das avaliações para {name}",
   "review-form": "Formulário de avaliação",
-  "reviews": "Mostre as avaliações de {name} aqui"
+  "reviews": "({total, plural, one {# review} other {# reviews}})"
 }

--- a/node/resolvers/reviews.ts
+++ b/node/resolvers/reviews.ts
@@ -81,7 +81,7 @@ export const queries = {
         return current_rating ? current_rating : { RatingValue: i, Count: 0 }
       })
 
-      const ratingOrders = reviews.Results[0].SecondaryRatingsOrder
+      const ratingOrders = reviews.Includes.Products[0].ReviewStatistics.SecondaryRatingsAveragesOrder
       reviews.Includes.Products[0].ReviewStatistics.SecondaryRatingsAverages = ratingOrders.map( (r:string) => {
         return parseSecondaryRatingsData(reviews.Includes.Products[0].ReviewStatistics.SecondaryRatingsAverages[r])
       })

--- a/react/RatingSummary.js
+++ b/react/RatingSummary.js
@@ -80,9 +80,11 @@ const Reviews = props => {
           </div>
         ) : (
           <Fragment>
-            <div className={`${styles.ratingSummaryStars} nowrap dib`}>
-              <Stars rating={average} />
-            </div>
+            <a href="#bazaarvoice-reviews">
+              <div className={`${styles.ratingSummaryStars} nowrap dib`}>
+                <Stars rating={average} />
+              </div>
+            </a>
             <span className={`${styles.ratingSummaryTotal} c-muted-2 t-body`}>
               ({totalReviews})
             </span>

--- a/react/RatingSummary.js
+++ b/react/RatingSummary.js
@@ -5,6 +5,7 @@ import withGetConfig from './components/withGetConfig'
 import { withApollo } from 'react-apollo'
 import { Link } from 'vtex.render-runtime'
 import Stars from './components/Stars'
+import { FormattedMessage } from 'react-intl'
 
 import styles from './styles.css'
 
@@ -80,13 +81,19 @@ const Reviews = props => {
           </div>
         ) : (
           <Fragment>
-            <a href="#bazaarvoice-reviews">
-              <div className={`${styles.ratingSummaryStars} nowrap dib`}>
-                <Stars rating={average} />
-              </div>
-            </a>
-            <span className={`${styles.ratingSummaryTotal} c-muted-2 t-body`}>
-              ({totalReviews})
+            <div className={`${styles.ratingSummaryStars} nowrap dib`}>
+              <Stars rating={average} />
+            </div>
+
+            <span
+              className={`${styles.ratingSummaryTotal} c-muted-2 t-body mr2`}
+            >
+              <a href="#bazaarvoice-reviews" className="c-link">
+                <FormattedMessage
+                  id="reviews"
+                  values={{ total: totalReviews }}
+                />
+              </a>
             </span>
             <Link
               className={`${styles.ratingSummaryWrite} ml2 c-link t-body`}

--- a/react/RatingSummary.js
+++ b/react/RatingSummary.js
@@ -88,7 +88,7 @@ const Reviews = props => {
             <span
               className={`${styles.ratingSummaryTotal} c-muted-2 t-body mr2`}
             >
-              <a href="#bazaarvoice-reviews" className="c-link">
+              <a href="#reviews" className="c-link">
                 <FormattedMessage
                   id="reviews"
                   values={{ total: totalReviews }}

--- a/react/Reviews.js
+++ b/react/Reviews.js
@@ -194,7 +194,6 @@ const Reviews = props => {
     selected,
     offset,
     count,
-    histogram,
     average,
     linkText,
     productId,

--- a/react/Reviews.js
+++ b/react/Reviews.js
@@ -260,7 +260,7 @@ const Reviews = props => {
   const fixedAverage = average.toFixed(1)
   return state.reviews.length ? (
     <div
-      id="bazaarvoice-reviews"
+      id="reviews"
       ref={containerRef}
       className={`${styles.reviews} mw8 center`}
     >

--- a/react/Reviews.js
+++ b/react/Reviews.js
@@ -301,7 +301,15 @@ const Reviews = props => {
       </Modal>
     </div>
   ) : (
-    <NoReviews productReference={productReference} linkText={linkText} />
+    <NoReviews
+      productReference={productReference}
+      linkText={linkText}
+      handleSort={handleSort}
+      selected={selected}
+      props={props}
+      handleFilter={handleFilter}
+      filter={filter}
+    />
   )
 }
 

--- a/react/Reviews.js
+++ b/react/Reviews.js
@@ -260,7 +260,11 @@ const Reviews = props => {
   }
   const fixedAverage = average.toFixed(1)
   return state.reviews.length ? (
-    <div ref={containerRef} className={`${styles.reviews} mw8 center`}>
+    <div
+      id="bazaarvoice-reviews"
+      ref={containerRef}
+      className={`${styles.reviews} mw8 center`}
+    >
       <h3 className={`${styles.reviewsTitle} t-heading-3 b--muted-5 mb5`}>
         Reviews
       </h3>

--- a/react/components/NoReviews.tsx
+++ b/react/components/NoReviews.tsx
@@ -1,9 +1,16 @@
 import React, { FunctionComponent } from 'react'
+import { Dropdown } from 'vtex.styleguide'
+import {options, filters} from './utils/dropdownOptions'
 import styles from '../styles.css'
 
 const NoReviews: FunctionComponent<NoReviewsProps> = ({
   productReference,
   linkText,
+  handleSort,
+  selected,
+  props,
+  handleFilter,
+  filter,
 }) => {
   return (
     <div className={`${styles.reviews} mw8 center c-on-base`}>
@@ -18,7 +25,25 @@ const NoReviews: FunctionComponent<NoReviewsProps> = ({
             No reviews found!
           </h5>
         </div>
-        <div className={styles.reviewsContainerWriteButton}>
+        <div className={`${styles.reviewsContainerDropdowns} flex mb7`}>
+          <div className={`${styles.reviewsContainerSortDropdown} mr4`}>
+            <Dropdown
+              options={options}
+              onChange={handleSort}
+              value={selected}
+              {...props}
+            />
+          </div>
+          <div className={styles.reviewsContainerStarsDropdown}>
+            <Dropdown
+              options={filters}
+              onChange={handleFilter}
+              value={filter}
+              {...props}
+            />
+          </div>
+        </div>
+        <div className={`${styles.reviewsContainerWriteButton} mb5`}>
           <a
             className={`${styles.writeReviewButton} bg-action-primary c-on-action-primary t-action link pv3 ph5`}
             href={`/new-review?product_id=${productReference}&return_page=/${linkText}/p`}
@@ -35,6 +60,11 @@ const NoReviews: FunctionComponent<NoReviewsProps> = ({
 interface NoReviewsProps {
   productReference: string
   linkText: string
+  handleSort: any
+  selected: string
+  props: any
+  handleFilter: any
+  filter: string
 }
 
 export default NoReviews

--- a/react/components/NoReviews.tsx
+++ b/react/components/NoReviews.tsx
@@ -12,6 +12,7 @@ const NoReviews: FunctionComponent<NoReviewsProps> = ({
   handleFilter,
   filter,
 }) => {
+  const isAllReviewsFilter = filter == '0'
   return (
     <div className={`${styles.reviews} mw8 center c-on-base`}>
       <h3 className={`${styles.reviewsTitle} t-heading-3 b--muted-5 mb5`}>
@@ -25,31 +26,34 @@ const NoReviews: FunctionComponent<NoReviewsProps> = ({
             No reviews found!
           </h5>
         </div>
-        <div className={`${styles.reviewsContainerDropdowns} flex mb7`}>
-          <div className={`${styles.reviewsContainerSortDropdown} mr4`}>
-            <Dropdown
-              options={options}
-              onChange={handleSort}
-              value={selected}
-              {...props}
-            />
+        {!isAllReviewsFilter && (
+          <div className={`${styles.reviewsContainerDropdowns} flex mb7`}>
+            <div className={`${styles.reviewsContainerSortDropdown} mr4`}>
+              <Dropdown
+                options={options}
+                onChange={handleSort}
+                value={selected}
+                {...props}
+              />
+            </div>
+            <div className={styles.reviewsContainerStarsDropdown}>
+              <Dropdown
+                options={filters}
+                onChange={handleFilter}
+                value={filter}
+                {...props}
+              />
+            </div>
           </div>
-          <div className={styles.reviewsContainerStarsDropdown}>
-            <Dropdown
-              options={filters}
-              onChange={handleFilter}
-              value={filter}
-              {...props}
-            />
-          </div>
-        </div>
+        )}
         <div className={`${styles.reviewsContainerWriteButton} mb5`}>
           <a
             className={`${styles.writeReviewButton} bg-action-primary c-on-action-primary t-action link pv3 ph5`}
             href={`/new-review?product_id=${productReference}&return_page=/${linkText}/p`}
           >
-            {' '}
-            Be the first to write a review!{' '}
+            {isAllReviewsFilter
+              ? 'Be the first to write a review!'
+              : 'Write a review'}
           </a>
         </div>
       </div>

--- a/react/components/NoReviews.tsx
+++ b/react/components/NoReviews.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react'
 import { Dropdown } from 'vtex.styleguide'
-import {options, filters} from './utils/dropdownOptions'
+import { options, filters } from './utils/dropdownOptions'
 import styles from '../styles.css'
 
 const NoReviews: FunctionComponent<NoReviewsProps> = ({

--- a/react/components/ReviewsContainer.tsx
+++ b/react/components/ReviewsContainer.tsx
@@ -1,57 +1,8 @@
 import React, { FunctionComponent, Fragment } from 'react'
 import { Dropdown } from 'vtex.styleguide'
 import Review from './Review'
+import {options, filters} from './utils/dropdownOptions'
 import styles from '../styles.css'
-
-const options = [
-  {
-    label: 'Most Recent',
-    value: 'SubmissionTime:desc',
-  },
-  {
-    label: 'Most Relevant',
-    value: 'Helpfulness:desc,SubmissionTime:desc',
-  },
-  {
-    label: 'Highest to Lowest Rating',
-    value: 'Rating:desc',
-  },
-  {
-    label: 'Lowest to Highest Rating',
-    value: 'Rating:asc',
-  },
-  {
-    label: 'Most Helpful',
-    value: 'Helpfulness:desc',
-  },
-]
-
-const filters = [
-  {
-    label: 'All',
-    value: '0',
-  },
-  {
-    label: '1 star',
-    value: '1',
-  },
-  {
-    label: '2 stars',
-    value: '2',
-  },
-  {
-    label: '3 stars',
-    value: '3',
-  },
-  {
-    label: '4 stars',
-    value: '4',
-  },
-  {
-    label: '5 stars',
-    value: '5',
-  },
-]
 
 const ReviewsContainer: FunctionComponent<ReviewsContainerProps> = ({
   count,

--- a/react/components/utils/dropdownOptions.tsx
+++ b/react/components/utils/dropdownOptions.tsx
@@ -1,0 +1,49 @@
+export const options = [
+  {
+    label: 'Most Recent',
+    value: 'SubmissionTime:desc',
+  },
+  {
+    label: 'Most Relevant',
+    value: 'Helpfulness:desc,SubmissionTime:desc',
+  },
+  {
+    label: 'Highest to Lowest Rating',
+    value: 'Rating:desc',
+  },
+  {
+    label: 'Lowest to Highest Rating',
+    value: 'Rating:asc',
+  },
+  {
+    label: 'Most Helpful',
+    value: 'Helpfulness:desc',
+  },
+]
+
+export const filters = [
+  {
+    label: 'All',
+    value: '0',
+  },
+  {
+    label: '1 star',
+    value: '1',
+  },
+  {
+    label: '2 stars',
+    value: '2',
+  },
+  {
+    label: '3 stars',
+    value: '3',
+  },
+  {
+    label: '4 stars',
+    value: '4',
+  },
+  {
+    label: '5 stars',
+    value: '5',
+  },
+]


### PR DESCRIPTION
#### What is the purpose of this pull request?
The reviews page was weird when there were no reviews to show
![image](https://user-images.githubusercontent.com/8443580/64289077-f01c9000-cf39-11e9-9342-f98a2a521e0a.png)

This was fixed, and now if the user clicks on the rating summary stars the window will scroll down to the reviews.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--ecowaterqa.myvtex.com/whirlpool-central-water-filtration-system/p#bazaarvoice-reviews)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/64357562-47267180-cfdb-11e9-979a-f1af62f64094.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
