### PR TITLE
QuantityPerPage and DefaultOrdinationType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- quantityPerPage and quantityFirstPage on Reviews
 
 ## [1.2.2] - 2019-09-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - quantityPerPage and quantityFirstPage on Reviews
+- `default ordination type` to the app's settings
 
 ## [1.2.2] - 2019-09-05
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -22,4 +22,5 @@ type GetConfigResponse {
   clientName: String
   siteId: String
   uniqueId: String
+  defaultOrdinationType: String
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -4,7 +4,7 @@
 # The resolvers for this query are implemented in here: node/graphql/index.ts
 
 type Query {
-  productReviews(sort: String!, filter: Int, offset: Int, pageId: String): Review @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
+  productReviews(sort: String!, filter: Int, offset: Int, pageId: String, quantity: Int): Review @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
   getConfig: GetConfigResponse @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -69,6 +69,26 @@
         "default": "linkText",
         "title": "API Unique Id",
         "description": "The Unique Id referencing to the product id to get the reviews"
+      },
+      "defaultOrdinationType": {
+        "type": "string",
+        "title": "Default Ordination Type",
+        "description": "The default ordination type of the reviews",
+        "default": "Helpfulness:desc,SubmissionTime:desc",
+        "enum": [
+          "SubmissionTime:desc",
+          "Helpfulness:desc,SubmissionTime:desc",
+          "Rating:desc",
+          "Rating:asc",
+          "Helpfulness:desc"
+        ],
+        "enumNames": [
+          "Most Recent",
+          "Most Relevant",
+          "Rating - Highest to Lowest",
+          "Rating - Lowest to Highest",
+          "Most Helpful"
+        ]
       }
     }
   },

--- a/node/clients/reviews.ts
+++ b/node/clients/reviews.ts
@@ -6,6 +6,7 @@ type GetReviewArgs = {
   sort: string;
   offset: string;
   filter: string;
+  quantity: number;
 }
 
 export default class Reviews extends ExternalClient {
@@ -13,8 +14,8 @@ export default class Reviews extends ExternalClient {
     super('http://api.bazaarvoice.com', context, options)
   }
 
-  public async getReviews ({ appKey, fieldProductId, sort, offset, filter }: GetReviewArgs): Promise<string> {
-    const endpoint = `/data/reviews.json?apiversion=5.4&passkey=${appKey}&Filter=ProductId:eq:${fieldProductId}&Sort=${sort}&Limit=10&Offset=${offset}&Include=Products&Stats=Reviews&Filter=${
+  public async getReviews ({ appKey, fieldProductId, sort, offset, filter, quantity }: GetReviewArgs): Promise<string> {
+    const endpoint = `/data/reviews.json?apiversion=5.4&passkey=${appKey}&Filter=ProductId:eq:${fieldProductId}&Sort=${sort}&Limit=${quantity}&Offset=${offset}&Include=Products&Stats=Reviews&Filter=${
       filter ? 'Rating:eq:' + filter : 'IsRatingsOnly:eq:false'
     }`
     

--- a/node/resolvers/reviews.ts
+++ b/node/resolvers/reviews.ts
@@ -6,6 +6,8 @@ declare var process: {
   }
 }
 
+const DEFAULT_REVIEWS_QUANTITY = 10
+
 /*This is a hack used to test the layout on some stores, but this should NEVER be used in
 practice because this is an extremely bad design choice that does not scale. The stores
 should configure bazaarvoice secondary ratings to have labels. */
@@ -49,7 +51,7 @@ export const queries = {
     const fieldProductId = product[uniqueId]
 
     let reviews: any
-    const newQuantity = quantity ? quantity : 10
+    const newQuantity = quantity || DEFAULT_REVIEWS_QUANTITY
     try {
       reviews = await reviewsClient.getReviews({appKey, fieldProductId, sort, offset, filter, quantity: newQuantity})
     } catch (error) {

--- a/node/resolvers/reviews.ts
+++ b/node/resolvers/reviews.ts
@@ -38,7 +38,7 @@ const convertSecondaryRatings = (secondaryRatings: any, ratingOrder: Array<any>)
 
 export const queries = {
   productReviews: async (_: any, args: any, ctx: Context) => {
-    const { sort, offset, pageId, filter } = args
+    const { sort, offset, pageId, filter, quantity } = args
     const { clients: { apps, reviews: reviewsClient }} = ctx
 
     const appId = process.env.VTEX_APP_ID
@@ -49,8 +49,9 @@ export const queries = {
     const fieldProductId = product[uniqueId]
 
     let reviews: any
+    const newQuantity = quantity ? quantity : 10
     try {
-      reviews = await reviewsClient.getReviews({appKey, fieldProductId, sort, offset, filter})
+      reviews = await reviewsClient.getReviews({appKey, fieldProductId, sort, offset, filter, quantity: newQuantity})
     } catch (error) {
       throw new TypeError(error.response.data)
     }

--- a/react/Reviews.js
+++ b/react/Reviews.js
@@ -25,7 +25,7 @@ const initialState = {
   count: 0,
   percentage: [],
   selected: 'Helpfulness:desc,SubmissionTime:desc',
-  isFirstRender: true,
+  loadedConfigData: false,
   filter: '0',
   paging: {},
   offset: 0,
@@ -48,10 +48,10 @@ const reducer = (state, action) => {
         hasError: false,
       }
     }
-    case 'SET_FIRST_RENDER': {
+    case 'SET_LOADED_CONFIG_DATA': {
       return {
         ...state,
-        isFirstRender: false,
+        loadedConfigData: true,
       }
     }
     case 'SET_SELECTED_SORT': {
@@ -150,13 +150,15 @@ const Reviews = ({
     offset == 0 ? quantityFirstPage : quantityPerPage
 
   useEffect(() => {
-    console.log('props', props)
     if (!linkText && !productId && !productReference) {
       return
     }
-    if (!props.data.loading && state.isFirstRender) {
+    if (props.data.loading) {
+      return
+    }
+    if (!props.data.loading && !state.loadedConfigData) {
       dispatch({
-        type: 'SET_FIRST_RENDER',
+        type: 'SET_LOADED_CONFIG_DATA',
       })
       if (
         props.data.getConfig.defaultOrdinationType &&
@@ -168,9 +170,6 @@ const Reviews = ({
           selectedSort: props.data.getConfig.defaultOrdinationType,
         })
       }
-    }
-    if (props.data.loading) {
-      return
     }
     client
       .query({

--- a/react/Reviews.js
+++ b/react/Reviews.js
@@ -134,6 +134,22 @@ const reducer = (state, action) => {
   }
 }
 
+const useDefaultSort = (dispatch, props, state) => {
+  useEffect(() => {
+    if (!props.data.loading && !state.loadedConfigData) {
+      dispatch({
+        type: 'SET_LOADED_CONFIG_DATA',
+      })
+      if (props.data.getConfig.defaultOrdinationType) {
+        dispatch({
+          type: 'SET_SELECTED_SORT',
+          selectedSort: props.data.getConfig.defaultOrdinationType,
+        })
+      }
+    }
+  })
+}
+
 const Reviews = ({
   client,
   quantityPerPage = 10,
@@ -149,27 +165,11 @@ const Reviews = ({
   const reviewsQuantityToShow =
     offset == 0 ? quantityFirstPage : quantityPerPage
 
+  useDefaultSort(dispatch, props, state)
+
   useEffect(() => {
     if (!linkText && !productId && !productReference) {
       return
-    }
-    if (props.data.loading) {
-      return
-    }
-    if (!props.data.loading && !state.loadedConfigData) {
-      dispatch({
-        type: 'SET_LOADED_CONFIG_DATA',
-      })
-      if (
-        props.data.getConfig.defaultOrdinationType &&
-        props.data.getConfig.defaultOrdinationType != null &&
-        props.data.getConfig.defaultOrdinationType != ''
-      ) {
-        dispatch({
-          type: 'SET_SELECTED_SORT',
-          selectedSort: props.data.getConfig.defaultOrdinationType,
-        })
-      }
     }
     client
       .query({

--- a/react/Reviews.js
+++ b/react/Reviews.js
@@ -25,6 +25,7 @@ const initialState = {
   count: 0,
   percentage: [],
   selected: 'Helpfulness:desc,SubmissionTime:desc',
+  isFirstRender: true,
   filter: '0',
   paging: {},
   offset: 0,
@@ -45,6 +46,12 @@ const reducer = (state, action) => {
         count: action.count,
         paging: action.paging,
         hasError: false,
+      }
+    }
+    case 'SET_FIRST_RENDER': {
+      return {
+        ...state,
+        isFirstRender: false,
       }
     }
     case 'SET_SELECTED_SORT': {
@@ -133,7 +140,6 @@ const Reviews = ({
   quantityFirstPage = quantityPerPage,
   ...props
 }) => {
-  initialState.selected = props.data.getConfig.defaultOrdinationType
   const { product } = useContext(ProductContext)
   const { linkText, productId, productReference } = product || {}
 
@@ -144,7 +150,26 @@ const Reviews = ({
     offset == 0 ? quantityFirstPage : quantityPerPage
 
   useEffect(() => {
+    console.log('props', props)
     if (!linkText && !productId && !productReference) {
+      return
+    }
+    if (!props.data.loading && state.isFirstRender) {
+      dispatch({
+        type: 'SET_FIRST_RENDER',
+      })
+      if (
+        props.data.getConfig.defaultOrdinationType &&
+        props.data.getConfig.defaultOrdinationType != null &&
+        props.data.getConfig.defaultOrdinationType != ''
+      ) {
+        dispatch({
+          type: 'SET_SELECTED_SORT',
+          selectedSort: props.data.getConfig.defaultOrdinationType,
+        })
+      }
+    }
+    if (props.data.loading) {
       return
     }
     client
@@ -209,6 +234,7 @@ const Reviews = ({
     productId,
     productReference,
     client,
+    props.data.loading,
   ])
 
   const handleSort = useCallback(

--- a/react/Reviews.js
+++ b/react/Reviews.js
@@ -127,18 +127,28 @@ const reducer = (state, action) => {
   }
 }
 
-const Reviews = props => {
+const Reviews = ({
+  client,
+  quantityPerPage = 10,
+  quantityFirstPage = quantityPerPage,
+  ...props
+}) => {
   const { product } = useContext(ProductContext)
   const { linkText, productId, productReference } = product || {}
 
   const [state, dispatch] = useReducer(reducer, initialState)
   const { filter, selected, offset, count, histogram, average } = state
 
+  console.log('props', props)
+
+  const reviewsQuantityToShow =
+    offset == 0 ? quantityFirstPage : quantityPerPage
+
   useEffect(() => {
     if (!linkText && !productId && !productReference) {
       return
     }
-    props.client
+    client
       .query({
         query: queryRatingSummary,
         variables: {
@@ -150,6 +160,7 @@ const Reviews = props => {
             productReference: productReference,
           }),
           filter: parseInt(filter) || 0,
+          quantity: reviewsQuantityToShow,
         },
       })
       .then(response => {
@@ -198,7 +209,7 @@ const Reviews = props => {
     linkText,
     productId,
     productReference,
-    props.client,
+    client,
   ])
 
   const handleSort = useCallback(

--- a/react/Reviews.js
+++ b/react/Reviews.js
@@ -134,20 +134,25 @@ const reducer = (state, action) => {
   }
 }
 
-const useDefaultSort = (dispatch, props, state) => {
+const useDefaultSort = (
+  dispatch,
+  loading,
+  defaultOrdinationType,
+  loadedConfigData
+) => {
   useEffect(() => {
-    if (!props.data.loading && !state.loadedConfigData) {
+    if (!loading && !loadedConfigData) {
       dispatch({
         type: 'SET_LOADED_CONFIG_DATA',
       })
-      if (props.data.getConfig.defaultOrdinationType) {
+      if (defaultOrdinationType) {
         dispatch({
           type: 'SET_SELECTED_SORT',
-          selectedSort: props.data.getConfig.defaultOrdinationType,
+          selectedSort: defaultOrdinationType,
         })
       }
     }
-  })
+  }, [loading])
 }
 
 const Reviews = ({
@@ -165,7 +170,12 @@ const Reviews = ({
   const reviewsQuantityToShow =
     offset == 0 ? quantityFirstPage : quantityPerPage
 
-  useDefaultSort(dispatch, props, state)
+  useDefaultSort(
+    dispatch,
+    props.data.loading,
+    props.data.getConfig.defaultOrdinationType,
+    state.loadedConfigData
+  )
 
   useEffect(() => {
     if (!linkText && !productId && !productReference) {
@@ -233,7 +243,6 @@ const Reviews = ({
     productId,
     productReference,
     client,
-    props.data.loading,
   ])
 
   const handleSort = useCallback(

--- a/react/Reviews.js
+++ b/react/Reviews.js
@@ -24,7 +24,7 @@ const initialState = {
   secondaryRatingsAverage: [],
   count: 0,
   percentage: [],
-  selected: 'SubmissionTime:desc',
+  selected: 'Helpfulness:desc,SubmissionTime:desc',
   filter: '0',
   paging: {},
   offset: 0,
@@ -133,13 +133,12 @@ const Reviews = ({
   quantityFirstPage = quantityPerPage,
   ...props
 }) => {
+  initialState.selected = props.data.getConfig.defaultOrdinationType
   const { product } = useContext(ProductContext)
   const { linkText, productId, productReference } = product || {}
 
   const [state, dispatch] = useReducer(reducer, initialState)
   const { filter, selected, offset, count, histogram, average } = state
-
-  console.log('props', props)
 
   const reviewsQuantityToShow =
     offset == 0 ? quantityFirstPage : quantityPerPage

--- a/react/components/NoReviews.tsx
+++ b/react/components/NoReviews.tsx
@@ -23,7 +23,11 @@ const NoReviews: FunctionComponent<NoReviewsProps> = ({
           <h5
             className={`${styles.reviewsContainerTitle} lh-copy mw9 t-heading-5 mv5`}
           >
-            No reviews found!
+            {isAllReviewsFilter
+              ? 'There are no reviews for this product yet'
+              : `There are no reviews with ${filter} ${
+                  filter == '1' ? 'star' : 'stars'
+                }`}
           </h5>
         </div>
         {!isAllReviewsFilter && (

--- a/react/components/utils/dropdownOptions.tsx
+++ b/react/components/utils/dropdownOptions.tsx
@@ -8,11 +8,11 @@ export const options = [
     value: 'Helpfulness:desc,SubmissionTime:desc',
   },
   {
-    label: 'Highest to Lowest Rating',
+    label: 'Rating - Highest to Lowest',
     value: 'Rating:desc',
   },
   {
-    label: 'Lowest to Highest Rating',
+    label: 'Rating - Lowest to Highest',
     value: 'Rating:asc',
   },
   {

--- a/react/graphql/getConfig.gql
+++ b/react/graphql/getConfig.gql
@@ -4,5 +4,6 @@ query getConfig {
     clientName
     siteId
     uniqueId
+    defaultOrdinationType
   }
 }

--- a/react/graphql/queries/queryRatingSummary.gql
+++ b/react/graphql/queries/queryRatingSummary.gql
@@ -1,5 +1,5 @@
-query productReviews($sort: String!, $filter: Int, $offset: Int, $pageId: String) {
-	productReviews(sort: $sort, offset: $offset, pageId: $pageId, filter: $filter) {
+query productReviews($sort: String!, $filter: Int, $offset: Int, $pageId: String, $quantity: Int) {
+	productReviews(sort: $sort, offset: $offset, pageId: $pageId, filter: $filter, quantity: $quantity) {
     Limit
     Offset
     TotalResults


### PR DESCRIPTION
#### What is the purpose of this pull request?
The `Reviews` component now receives two new props:
`quantityPerPage`: the number of reviews that will be showed in each review page (default of 10).
`quantityFirstPage`: the number of reviews that will be showed on the first review page (default is to be the same as `quantityPerPage`)

Also, it is now possible to define the default ordination type of reviews through the app's settings.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--ecowaterqa.myvtex.com/whirlpool-central-water-filtration-system/p#reviews)

#### Screenshots or example usage

https://iaronaraujo--ecowaterqa.myvtex.com/whirlpool-central-water-filtration-system/p#reviews

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
