### PR TITLE
Fix transaction event values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `total` field of the `Transaction` event.
+
+### Added
+- `discount` and `productId` to the `Transaction` event.
 
 ## [1.5.6] - 2019-11-18
 ### Fixed

--- a/node/package.json
+++ b/node/package.json
@@ -12,7 +12,7 @@
     "eslint": "^5.16.0",
     "eslint-config-vtex": "^10.1.0",
     "prettier": "^1.18.2",
-    "typescript": "3.5.2"
+    "typescript": "3.7.3"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2524,10 +2524,10 @@ type-is@^1.6.16, type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 universalify@^0.1.0:
   version "0.1.2"

--- a/react/BazaarvoicePixel.tsx
+++ b/react/BazaarvoicePixel.tsx
@@ -7,7 +7,7 @@ export function handleEvents(e: PixelMessage) {
       const data = e.data
       const transactionData = {
         orderId: data.orderGroup,
-        total: data.transactionSubtotal,
+        total: data.transactionSubtotal - Math.abs(data.transactionDiscounts),
         currency: data.currency,
         tax: data.transactionTax,
         shipping: data.transactionShipping,
@@ -15,9 +15,12 @@ export function handleEvents(e: PixelMessage) {
         state: data.visitorAddressState,
         email: data.visitorContactInfo[0],
         nickname: data.visitorContactInfo[1],
+        discount: Math.abs(data.transactionDiscounts),
         items: data.transactionProducts.map(product => {
           return {
+            productId: product.id,
             sku: product.sku,
+            discount: product.originalPrice - product.price,
             quantity: product.quantity,
             name: product.name,
             price: product.price,

--- a/react/package.json
+++ b/react/package.json
@@ -23,7 +23,7 @@
     "eslint-config-vtex-react": "^4.1.0",
     "prettier": "^1.18.2",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.5.2"
+    "typescript": "3.7.3"
   },
   "version": "1.5.6"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5215,7 +5215,12 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.5.2, typescript@^3.3.3333:
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+
+typescript@^3.3.3333:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
   integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==


### PR DESCRIPTION
#### What is the purpose of this pull request?
Previously the `total` field of the `trackTransaction` event didn't have the correct value. This PR fixes that and also adds a few more fields to this kind of event.

#### How should this be manually tested?
You have to activate an `orderPlaced` event on ecowater and check the `Transaction` event through the bazaarvoice chrome extension.

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
