### PR TITLE
Fix product review link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Product review link.
 
 ## [1.6.0] - 2020-08-27
 ### Added

--- a/react/Reviews.js
+++ b/react/Reviews.js
@@ -167,7 +167,7 @@ const Reviews = ({
   const reviewsQuantityToShow =
     offset == 0 ? quantityFirstPage : quantityPerPage
 
-  const productIdentifier = appSettings.uniqueId
+  const productIdentifier = product[appSettings.uniqueId]
 
   useDefaultSort(dispatch, appSettings, state.loadedConfigData)
 
@@ -351,7 +351,7 @@ const Reviews = ({
     </div>
   ) : (
     <NoReviews
-      productReference={productReference}
+      productIdentifier={productIdentifier}
       linkText={linkText}
       handleSort={handleSort}
       selected={selected}

--- a/react/components/NoReviews.tsx
+++ b/react/components/NoReviews.tsx
@@ -4,7 +4,7 @@ import { options, filters } from './utils/dropdownOptions'
 import styles from '../styles.css'
 
 const NoReviews: FunctionComponent<NoReviewsProps> = ({
-  productReference,
+  productIdentifier,
   linkText,
   handleSort,
   selected,
@@ -53,7 +53,7 @@ const NoReviews: FunctionComponent<NoReviewsProps> = ({
         <div className={`${styles.reviewsContainerWriteButton} mb5`}>
           <a
             className={`${styles.writeReviewButton} bg-action-primary c-on-action-primary t-action link pv3 ph5`}
-            href={`/new-review?product_id=${productReference}&return_page=/${linkText}/p`}
+            href={`/new-review?product_id=${productIdentifier}&return_page=/${linkText}/p`}
           >
             {isAllReviewsFilter
               ? 'Be the first to write a review!'
@@ -66,7 +66,7 @@ const NoReviews: FunctionComponent<NoReviewsProps> = ({
 }
 
 interface NoReviewsProps {
-  productReference: string
+  productIdentifier: string
   linkText: string
   handleSort: any
   selected: string


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the review form link.

#### What problem is this solving?

Open this page:
https://ecowaterqa.myvtex.com/brita-under-sink-main-kitchen-bathroom-water-filter/p
Hover the "Write a Review" button *on the bottom of the page* (the one next to the stars it's OK)
![image](https://user-images.githubusercontent.com/284515/93486547-b61af380-f8da-11ea-9241-eca283dcbb9f.png)

#### How should this be manually tested?

Fixed workspace:
https://brenovtex--ecowaterqa.myvtex.com/brita-under-sink-main-kitchen-bathroom-water-filter/p

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/284515/93486620-cb901d80-f8da-11ea-9f12-a9ecfe7a5289.png)


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
