### PR TITLE
Prevent multiple navigate calls on review submitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Continuous returnPage redirect on review submission  
+
 ## [1.6.1] - 2020-09-17
 ### Fixed
 - Product review link.

--- a/react/ReviewForm.tsx
+++ b/react/ReviewForm.tsx
@@ -38,7 +38,7 @@ const ReviewForm = ({ appSettings }: { appSettings: Settings }) => {
         },
         submissionSubmitted: function() {
           if (query.return_page) {
-            setInterval(() => navigate({ to: query.return_page }), 1000)
+            setTimeout(() => navigate({ to: query.return_page }), 1000)
           }
         },
       },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Prevent continuous page redirect when a product review is submitted. 

#### What problem is this solving?

Once a product review is submitted, the page is continuously refreshed.

#### How should this be manually tested?

[workspace](https://ecowaterqa.myvtex.com/new-review?workspace=submit&product_id=1&return_page=/whirlpool-central-water-filtration-system/p?workspace=submit)
Note `?workspace=submit` in both the site URL and return_page param

#### Screenshots or example usage

https://www.loom.com/share/6ea734be4f75425eb082bcb111dffeeb

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
