### PR TITLE
Fix/pixel order values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Product @id field to schema
+
+### Fixed
+
+- Bazaarvoice transaction pixel order values
+
 ## [1.8.2] - 2021-01-05
 
 ### Added
+
 - Add metadata to app store
 
 ## [1.8.1] - 2020-12-02

--- a/node/package.json
+++ b/node/package.json
@@ -7,7 +7,7 @@
     "axios": "^0.18.0"
   },
   "devDependencies": {
-    "@vtex/api": "6.37.0",
+    "@vtex/api": "6.37.1",
     "@vtex/tsconfig": "^0.4.4",
     "typescript": "3.9.7",
     "vtex.pixel-interfaces": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-interfaces@1.1.1/public/_types/react",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -134,10 +134,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.37.0":
-  version "6.37.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.0.tgz#a07e6adbfc02866f901cf0cfff2155f2c279adc5"
-  integrity sha512-Vy970ZfgOttrxeiJW2oM8rQ0E8t/HE5cQhbGIawfJsu35HEWA9NnWRSR3bdLMczT9oYIY9QwE8IfdU4b44dhKw==
+"@vtex/api@6.37.1":
+  version "6.37.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.1.tgz#d6ded4f4a98e10596729af7097cff18be43a0e54"
+  integrity sha512-24BaVHCIbkC84UWAlGPuTnUYIFngOpeRa4u/6KCJDnir5GXjoCWAkj4E7OoQ2uvBy/uvs9X2+DIkqtiz1x5bvw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1260,7 +1260,7 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -1413,10 +1413,6 @@ vary@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
-
-"vtex.bazaarvoice@https://bazaarvoice--sandboxusdev.myvtex.com/_v/private/typings/linked/v1/vtex.bazaarvoice@1.8.0+build1606848694/public/@types/vtex.bazaarvoice":
-  version "1.8.0"
-  resolved "https://bazaarvoice--sandboxusdev.myvtex.com/_v/private/typings/linked/v1/vtex.bazaarvoice@1.8.0+build1606848694/public/@types/vtex.bazaarvoice#0df8ac0a59c047081bb4bcc7787ec113821dbf4c"
 
 "vtex.pixel-interfaces@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-interfaces@1.1.1/public/_types/react":
   version "0.0.0"

--- a/react/BazaarvoicePixel.tsx
+++ b/react/BazaarvoicePixel.tsx
@@ -9,7 +9,10 @@ export function handleEvents(e: PixelMessage) {
       const { data } = e
       const transactionData = {
         orderId: data.orderGroup,
-        total: data.transactionSubtotal - Math.abs(data.transactionDiscounts),
+        total:
+          Math.round(
+            data.transactionSubtotal + data.transactionDiscounts * 100
+          ) / 100,
         currency: data.currency,
         tax: data.transactionTax,
         shipping: data.transactionShipping,
@@ -17,15 +20,15 @@ export function handleEvents(e: PixelMessage) {
         state: data.visitorAddressState,
         email: data.visitorContactInfo[0],
         nickname: data.visitorContactInfo[1],
-        discount: Math.abs(data.transactionDiscounts),
         items: data.transactionProducts.map((product) => {
           return {
             productId: getProductId(product),
             sku: product.sku,
-            discount: product.originalPrice - product.price,
+            discount:
+              Math.round((product.originalPrice - product.price) * 100) / 100,
             quantity: product.quantity,
             name: product.name,
-            price: product.price,
+            price: product.originalPrice,
             category: product.category,
           }
         }),

--- a/react/components/AggregateStructuredData.tsx
+++ b/react/components/AggregateStructuredData.tsx
@@ -18,6 +18,7 @@ const AggregateStructuredData: FC<Props> = ({
   const aggregate = {
     '@context': 'http://schema.org',
     '@type': 'Product',
+    '@id': window.location.href,
     name: productName,
     aggregateRating: {
       '@type': 'AggregateRating',

--- a/react/components/ReviewStructuredData.tsx
+++ b/react/components/ReviewStructuredData.tsx
@@ -14,6 +14,7 @@ const ReviewStructuredData: FC<Props> = ({ productName, review }) => {
   const reviewStructuredData = {
     '@context': 'http://schema.org',
     '@type': 'Product',
+    '@id': window.location.href,
     name: productName,
     review: {
       '@type': 'Review',


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

- Fix order values being recorded by the BV pixel.
- Added `@id` field to product schema
 
https://vtex-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=121&projectKey=U1PA&modal=detail&selectedIssue=U1PA-357

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
- BV was calculating the order discount twice.
- The product price passed to BV was the discounted price, while BV expected the original price, before discount.
- BV does not accept values with more 2 decimal places.

#### How should this be manually tested?
Difficult to test without access to BazaarVoice admin panel. To be validated by the client. 

https://ecowaterqa.myvtex.com/whirlpool-pro-series-water-softener-whole-home-filter-hybrid/p?workspace=bvquestions 

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
