### PR TITLE
Feature/review image display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Modal to display full sized review images
+
+### Fixed
+
+- Review image thumbnail sizing
+
 ## [1.8.3] - 2021-01-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Review image thumbnail sizing
+- Use locale review count in Rating Summary
 
 ## [1.8.3] - 2021-01-08
 

--- a/manifest.json
+++ b/manifest.json
@@ -42,9 +42,7 @@
   ],
   "mustUpdateAt": "2020-01-22",
   "categories": [],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },
@@ -80,11 +78,7 @@
       "uniqueId": {
         "type": "string",
         "access": "public",
-        "enum": [
-          "productId",
-          "linkText",
-          "productReference"
-        ],
+        "enum": ["productId", "linkText", "productReference"],
         "default": "linkText",
         "title": "API Unique Id",
         "description": "The Unique Id referencing to the product id to get the reviews"
@@ -125,6 +119,7 @@
     "vtex.product-summary-context": "0.x",
     "vtex.store-header": "2.x",
     "vtex.store": "2.x",
+    "vtex.slider-layout": "0.x",
     "vtex.product-context": "0.x",
     "vtex.pixel-interfaces": "1.x"
   },

--- a/react/RatingSummary.tsx
+++ b/react/RatingSummary.tsx
@@ -33,9 +33,8 @@ const RatingSummary = ({ appSettings }: { appSettings: Settings }) => {
       : null
 
   const totalReviews =
-    !loading && !error && data && data.productReviews.Includes.Products[0]
-      ? data.productReviews.Includes.Products[0].ReviewStatistics
-          .TotalReviewCount
+    !loading && !error && data && data.productReviews
+      ? data.productReviews.TotalResults
       : null
 
   const { uniqueId } = appSettings

--- a/react/components/Review.tsx
+++ b/react/components/Review.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useContext } from 'react'
-import { defineMessages, useIntl } from 'react-intl'
+import { defineMessages, useIntl, IntlShape } from 'react-intl'
 import { ProductContext } from 'vtex.product-context'
 
 import Stars from './Stars'
@@ -11,6 +11,7 @@ import {
   useTrackViewedCGC,
 } from '../modules/trackers'
 import ReviewStructuredData from './ReviewStructuredData'
+import ReviewImages from './ReviewImages'
 
 const messages = defineMessages({
   timeAgo: {
@@ -71,7 +72,7 @@ const messages = defineMessages({
   },
 })
 
-const getTimeAgo = (intl: any, time: string) => {
+const getTimeAgo = (intl: IntlShape, time: string) => {
   const before = new Date(time)
   const now = new Date()
   const diff = new Date(now.valueOf() - before.valueOf())
@@ -157,24 +158,7 @@ const Review: FunctionComponent<ReviewProps> = ({ review, appSettings }) => {
               review.UserLocation ? `, from ${review.UserLocation}` : ''
             }`}
           </div>
-
-          {review.Photos.length ? (
-            <div
-              className={`${styles.reviewImagesContainer} mt6 flex items-start`}
-            >
-              {review.Photos.map((item, i: number) => {
-                return (
-                  <img
-                    alt="Product"
-                    className={`${styles.reviewImage} w-20 db mb5`}
-                    key={i}
-                    src={item.Sizes.thumbnail.Url}
-                  />
-                )
-              })}
-            </div>
-          ) : null}
-
+          <ReviewImages review={review} />
           <p className={`${styles.reviewText} t-body lh-copy mw7 pr5-ns`}>
             {review.ReviewText}
           </p>

--- a/react/components/ReviewImages.tsx
+++ b/react/components/ReviewImages.tsx
@@ -1,0 +1,58 @@
+import React, { FunctionComponent, useState } from 'react'
+import { SliderLayout } from 'vtex.slider-layout'
+import { Modal } from 'vtex.styleguide'
+
+import Review from './Review'
+import styles from '../styles.css'
+
+const sliderLayoutConfig = {
+  showNavigationArrows: 'desktopOnly',
+  showPaginationDots: 'desktopOnly',
+  infinite: true,
+  itemsPerPage: 1,
+}
+
+const ReviewImages: FunctionComponent<{ review: Review }> = ({ review }) => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
+
+  if (!review.Photos.length) {
+    return null
+  }
+
+  return (
+    <div className={`${styles.reviewImagesContainer} mt6 flex items-start`}>
+      {review.Photos.map((item, i) => {
+        return (
+          <div
+            role="button"
+            tabIndex={0}
+            key={i}
+            onKeyPress={() => setIsModalOpen(true)}
+            onClick={() => setIsModalOpen(true)}
+          >
+            <img
+              alt="Product"
+              className={`${styles.reviewImage} db mr1 `}
+              src={item.Sizes.thumbnail.Url}
+            />
+          </div>
+        )
+      })}
+      <Modal
+        centered
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(!isModalOpen)}
+      >
+        <SliderLayout {...sliderLayoutConfig}>
+          {review.Photos.map((item, i) => (
+            <div className="pb5" key={i}>
+              <img src={item.Sizes.normal.Url} alt="Product" />
+            </div>
+          ))}
+        </SliderLayout>
+      </Modal>
+    </div>
+  )
+}
+
+export default ReviewImages

--- a/react/package.json
+++ b/react/package.json
@@ -30,6 +30,7 @@
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.1/public/@types/vtex.render-runtime",
     "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.109.3/public/@types/vtex.store",
     "vtex.store-header": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-header@2.25.6/public/_types/react",
+    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.115.0/public/_types/react",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.2/public/@types/vtex.styleguide"
   },
   "version": "1.8.3"

--- a/react/styles.css
+++ b/react/styles.css
@@ -136,6 +136,7 @@
 }
 
 .reviewImage {
+  cursor: pointer;
 }
 
 .reviewsContainer {

--- a/react/typings/vtex.slider-layout.d.ts
+++ b/react/typings/vtex.slider-layout.d.ts
@@ -1,0 +1,3 @@
+declare module 'vtex.slider-layout' {
+  export const SliderLayout: any
+}

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -1,3 +1,4 @@
 declare module 'vtex.styleguide' {
   export const Dropdown: any
+  export const Modal: any
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4924,6 +4924,10 @@ verror@1.10.0:
   version "8.126.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.1/public/@types/vtex.render-runtime#3c1b8e2f331ca7d3eaeda2f09a6509243e8f9e67"
 
+"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.115.0/public/_types/react":
+  version "0.0.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.115.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+
 "vtex.store-header@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-header@2.25.6/public/_types/react":
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-header@2.25.6/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
- Display review image thumbnails in their original size
- Add a modal to display full sized Review images
- Use review count for the user's locale in the Rating Summary component

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
- Review thumbnail images are being stretched beyound their original size and there is no way to view the full-sized image.
- Current review count in the Rating Summary includes reviews of all languages. This count does not match the count of readable reviews when reviews exist in multiple locales.

#### How should this be manually tested?

https://sdb--philipspt.myvtex.com/secador-de-cabelo-philips-bhd274-00-2200-w-motor-ac-trat-ionico-velocidade-do-ar-130km-h-difusor/p

#### Screenshots or example usage


![Screenshot from 2021-01-15 12-07-01](https://user-images.githubusercontent.com/22715037/104756876-5880a180-572a-11eb-8177-fa34f271db50.png)

![Screenshot from 2021-01-15 12-07-51](https://user-images.githubusercontent.com/22715037/104756887-5c142880-572a-11eb-9565-a931a6fb26bc.png)

![Screenshot from 2021-01-15 12-10-12](https://user-images.githubusercontent.com/22715037/104757166-b57c5780-572a-11eb-841f-cec26452a07c.png)

![Screenshot from 2021-01-15 12-10-23](https://user-images.githubusercontent.com/22715037/104757176-b8774800-572a-11eb-97b9-b7f712cea235.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
