### PR TITLE
Fix transaction pixel value data format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Transaction pixel value formatting
+
 ## [1.9.0] - 2021-01-15
 
 ### Added

--- a/react/BazaarvoicePixel.tsx
+++ b/react/BazaarvoicePixel.tsx
@@ -9,10 +9,9 @@ export function handleEvents(e: PixelMessage) {
       const { data } = e
       const transactionData = {
         orderId: data.orderGroup,
-        total:
-          Math.round(
-            data.transactionSubtotal + data.transactionDiscounts * 100
-          ) / 100,
+        total: (data.transactionSubtotal + data.transactionDiscounts).toFixed(
+          2
+        ),
         currency: data.currency,
         tax: data.transactionTax,
         shipping: data.transactionShipping,
@@ -24,11 +23,10 @@ export function handleEvents(e: PixelMessage) {
           return {
             productId: getProductId(product),
             sku: product.sku,
-            discount:
-              Math.round((product.originalPrice - product.price) * 100) / 100,
+            discount: (product.originalPrice - product.price).toFixed(2),
             quantity: product.quantity,
             name: product.name,
-            price: product.originalPrice,
+            price: product.originalPrice.toFixed(2),
             category: product.category,
           }
         }),

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -41,7 +41,7 @@ interface BazaarvoiceClient {
 
 interface TransactionData {
   orderId: string
-  total: number
+  total: string
   currency: string
   country: string
   state: string
@@ -52,7 +52,7 @@ interface BazaarvoiceItem {
   sku: string
   quantity: number
   name: string
-  price: number
+  price: string
   category: string
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Use string format in Bazaarvoice transaction pixel order totals

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

The Bazaarvoice transaction pixel expects totals to be in a string format:
![image002](https://user-images.githubusercontent.com/22715037/105530283-909d5c80-5cb5-11eb-9a59-13ed474ca17c.jpg)

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
