### PR TITLE
Adjust schema.org @id property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Adjust structured data `@id` property to match property from `vtex.structured-data`
+- Remove `AggregateStructuredData` from `Reviews` to prevent duplicate aggregate review data on the PDP
+
 ## [2.0.2] - 2021-02-10
 
 ### Fixed
+
 - Icon size
 
 ## [2.0.1] - 2021-02-03
 
 ### Added
+
 - Billingoptions to manifest
 
 ## [2.0.0] - 2021-01-22

--- a/node/package.json
+++ b/node/package.json
@@ -7,7 +7,7 @@
     "axios": "^0.18.0"
   },
   "devDependencies": {
-    "@vtex/api": "6.37.1",
+    "@vtex/api": "6.40.0",
     "@vtex/tsconfig": "^0.4.4",
     "typescript": "3.9.7",
     "vtex.pixel-interfaces": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-interfaces@1.1.1/public/_types/react",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -134,10 +134,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.37.1":
-  version "6.37.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.1.tgz#d6ded4f4a98e10596729af7097cff18be43a0e54"
-  integrity sha512-24BaVHCIbkC84UWAlGPuTnUYIFngOpeRa4u/6KCJDnir5GXjoCWAkj4E7OoQ2uvBy/uvs9X2+DIkqtiz1x5bvw==
+"@vtex/api@6.40.0":
+  version "6.40.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.40.0.tgz#830c4aaaad75a1a8cf86ce898010e081a89053f8"
+  integrity sha512-VDdg9KVoNQ6KxH6cM0Tgh+VF7ELLrORqk5lRaie4akUZXW2tqECFLZAvRi9UE29CLstqCLBGQjqxbuT1aj/mgQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/react/RatingSummary.tsx
+++ b/react/RatingSummary.tsx
@@ -52,6 +52,8 @@ const RatingSummary = ({ appSettings }: { appSettings: Settings }) => {
           <Fragment>
             <AggregateStructuredData
               productName={product?.productName}
+              productId={product?.productId}
+              productUrl={product?.link}
               average={average}
               total={totalReviews}
             />

--- a/react/Reviews.jsx
+++ b/react/Reviews.jsx
@@ -17,7 +17,6 @@ import ReviewsContainer from './components/ReviewsContainer'
 import queryRatingSummary from './graphql/queries/queryRatingSummary.gql'
 import { trackPageViewData } from './modules/trackers'
 import styles from './styles.css'
-import AggregateStructuredData from './components/AggregateStructuredData'
 
 const initialState = {
   reviews: null,
@@ -343,11 +342,6 @@ const Reviews = ({
           ({fixedAverage})
         </span>
       </div>
-      <AggregateStructuredData
-        productName={product && product.productName}
-        average={average}
-        total={state.count}
-      />
       <Histogram
         percentages={state.percentage}
         histogram={histogram}

--- a/react/components/AggregateStructuredData.tsx
+++ b/react/components/AggregateStructuredData.tsx
@@ -2,12 +2,16 @@ import React, { FC } from 'react'
 
 interface Props {
   productName: string
+  productId: string
+  productUrl: string
   average: number
   total: number
 }
 
 const AggregateStructuredData: FC<Props> = ({
   productName,
+  productId,
+  productUrl,
   average,
   total,
 }) => {
@@ -18,7 +22,8 @@ const AggregateStructuredData: FC<Props> = ({
   const aggregate = {
     '@context': 'http://schema.org',
     '@type': 'Product',
-    '@id': window.location.href,
+    '@id': productUrl,
+    mpn: productId,
     name: productName,
     aggregateRating: {
       '@type': 'AggregateRating',

--- a/react/components/Review.tsx
+++ b/react/components/Review.tsx
@@ -141,7 +141,12 @@ const Review: FunctionComponent<ReviewProps> = ({ review, appSettings }) => {
       id={elementId}
       className={`${styles.review} bw2 bb b--muted-5 mb5 pb4-ns pb8-s`}
     >
-      <ReviewStructuredData productName={product.productName} review={review} />
+      <ReviewStructuredData
+        productName={product.productName}
+        productId={product.productId}
+        productUrl={product.link}
+        review={review}
+      />
       <div className={`${styles.reviewRating} flex items-center`}>
         <Stars rating={review.Rating} />
         <span className="c-muted-1 t-small ml2">

--- a/react/components/ReviewStructuredData.tsx
+++ b/react/components/ReviewStructuredData.tsx
@@ -2,6 +2,8 @@ import React, { FC } from 'react'
 
 interface Props {
   productName: string
+  productId: string
+  productUrl: string
   review: {
     Rating: number
     UserNickname: string
@@ -10,11 +12,17 @@ interface Props {
   }
 }
 
-const ReviewStructuredData: FC<Props> = ({ productName, review }) => {
+const ReviewStructuredData: FC<Props> = ({
+  productName,
+  productId,
+  productUrl,
+  review,
+}) => {
   const reviewStructuredData = {
     '@context': 'http://schema.org',
     '@type': 'Product',
-    '@id': window.location.href,
+    '@id': productUrl,
+    mpn: productId,
     name: productName,
     review: {
       '@type': 'Review',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Related to https://github.com/vtex-apps/structured-data/pull/31

Modifies the schema.org structured data for BazaarVoice reviews so that Google correctly interprets it as part of the main product structured data on the PDP.

#### How should this be manually tested?

Linked in this workspace: https://arthur--ecowaterqa.myvtex.com/brita-under-sink-main-kitchen-bathroom-water-filter/p
Google Rich Results test showing the product data correctly consolidated: https://search.google.com/test/rich-results?id=aBhlwxTOAIlGqPM1JQG4gw

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
